### PR TITLE
マイグレーションファイルのロールバック記述を正しいテーブルに変更

### DIFF
--- a/database/migrations/2020_04_23_094641_add_user_id_to_posts_table.php
+++ b/database/migrations/2020_04_23_094641_add_user_id_to_posts_table.php
@@ -25,7 +25,7 @@ class AddUserIdToPostsTable extends Migration
      */
     public function down()
     {
-        Schema::table('posts', function (Blueprint $table) {
+        Schema::table('todos', function (Blueprint $table) {
             $table->dropColumn('deleted_at');
         });
     }


### PR DESCRIPTION
マイグレーションファイルのロールバック記述が別のテーブルになっていたのを変更